### PR TITLE
fix!: Remove support for variable types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ binbuf (short for *binary buffers*) is a small library to work with binary (netw
 
 ### Reading basic types
 
-The library provides multiple methods to read basic data types like `u8`, `u16`, `u32`, `u64`, `u128`, `usize`,
+The library provides multiple methods to read basic data types like `u8`, `u16`, `u32`, `u64`, `u128`,
 `Ipv4Addr`, and `Ipv6Addr` in big and little-endian byte order.
 
 ```rust

--- a/src/read.rs
+++ b/src/read.rs
@@ -470,4 +470,3 @@ from_buffer_and_readable_impl!(u16, 2);
 from_buffer_and_readable_impl!(u32, 4);
 from_buffer_and_readable_impl!(u64, 8);
 from_buffer_and_readable_impl!(u128, 16);
-from_buffer_and_readable_impl!(usize, (usize::BITS / 8) as usize);

--- a/src/write.rs
+++ b/src/write.rs
@@ -256,7 +256,6 @@ into_buffer_and_writeable_impl!(u16, 2);
 into_buffer_and_writeable_impl!(u32, 4);
 into_buffer_and_writeable_impl!(u64, 8);
 into_buffer_and_writeable_impl!(u128, 16);
-into_buffer_and_writeable_impl!(usize, (usize::BITS / 8) as usize);
 
 impl<T: Write> Write for Vec<T> {
     fn write<E: Endianness>(&self, buf: &mut Writer) -> Result {


### PR DESCRIPTION
Both `usize` and `isize` are platform dependent. It would be unsound to support these types.